### PR TITLE
new(nix): Added flake-based devshell setup leveraging your own flake / overlay

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 /classes
 /target
 .garden/
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "garden": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1726732424,
+        "narHash": "sha256-QX8bPuBvhmBLOiR0QYantHewSKH9n6L9QrCOzfLgV5Y=",
+        "owner": "nextjournal",
+        "repo": "garden-cli",
+        "rev": "72c00aee7b8e17c36c42e1f9f0db46b5e944b692",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nextjournal",
+        "repo": "garden-cli",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711532879,
+        "narHash": "sha256-VUvOxVoxBokiZETZdZU97MnJpeKa19KqSOPlC84QB9Y=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2230a20f2b5a14f2db3d7f13a2dc3c22517e790b",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1726583932,
+        "narHash": "sha256-zACxiQx8knB3F8+Ze+1BpiYrI+CbhxyWpcSID9kVhkQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "658e7223191d2598641d50ee4e898126768fe847",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "garden": "garden",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,8 @@
 
   outputs = { self, nixpkgs, garden }:
     let
+      # Latest LTS releases as of Nov 2023
+      javaVersion = 21;
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
         pkgs = import nixpkgs {
@@ -20,7 +22,7 @@
     in {
       devShells = forEachSupportedSystem ({ pkgs }: {
         default = pkgs.mkShell {
-            buildInputs = [ pkgs.garden ];
+            buildInputs = [ pkgs.clojure pkgs.garden ];
           };
       });
     };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "A Nix-flake-based development environment for application.garden";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    garden.url = "github:nextjournal/garden-cli";
+  };
+
+  outputs = { self, nixpkgs, garden }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            garden.overlays.default
+          ];
+        };
+      });
+    in {
+      devShells = forEachSupportedSystem ({ pkgs }: {
+        default = pkgs.mkShell {
+            buildInputs = [ pkgs.garden ];
+          };
+      });
+    };
+}


### PR DESCRIPTION
Added a local flake and .envrc to eliminate personal pain point during the workshop earlier :) Good session BTW - thanks for the intro.

Just clone the repo and then 'direnv allow'